### PR TITLE
docs: fix code typos in README

### DIFF
--- a/packages/gesturehandler/blueprint.md
+++ b/packages/gesturehandler/blueprint.md
@@ -6,6 +6,7 @@
 {{ template:toc }}
 
 ## Installation
+
 Run the following command from the root of your project:
 
 `ns plugin add {{ pkg.name }}`
@@ -13,16 +14,18 @@ Run the following command from the root of your project:
 ## API
 
 We need to do some wiring when your app starts, so open `app.ts` and add this before creating any View/App/Frame:
+
 ##### TypeScript
+
 ```ts
-import { install } from "@nativescript-community/gesturehandler";
+import { install } from '@nativescript-community/gesturehandler';
 install();
 ```
 
 You create a gesture handler using something like this:
-```typescript 
-import { GestureHandlerTouchEvent, GestureHandlerStateEvent, GestureStateEventData, GestureTouchEventData, HandlerType } from '@nativescript-community/gesturehandler';
 
+```typescript
+import { GestureHandlerTouchEvent, GestureHandlerStateEvent, GestureStateEventData, GestureTouchEventData, HandlerType, Manager } from '@nativescript-community/gesturehandler';
 
 function onGestureTouch(args: GestureTouchEventData) {
     const { state, extraData, view } = args.data;
@@ -34,7 +37,7 @@ function onGestureState(args: GestureStateEventData) {
     console.log('onGestureState', state, prevState, view, extraData);
 }
 const manager = Manager.getInstance();
-const gestureHandler = = manager.createGestureHandler(HandlerType.PAN, 10, {
+const gestureHandler = manager.createGestureHandler(HandlerType.PAN, 10, {
     shouldCancelWhenOutside: false
 });
 gestureHandler.on(GestureHandlerTouchEvent, onGestureTouch, this);
@@ -42,9 +45,9 @@ gestureHandler.on(GestureHandlerStateEvent, onGestureState, this);
 gestureHandler.attachToView(view);
 ```
 
-Right now you must not forget to store the ```gestureHandler``` somewhere or the gesture won't work on iOS (native object being released). This will be fixed in future versions.
+Right now you must not forget to store the `gestureHandler` somewhere or the gesture won't work on iOS (native object being released). This will be fixed in future versions.
 
-Now about the API. All the gestures for the react counterpart exist with the same options and the same event ```extraData```.
+Now about the API. All the gestures for the react counterpart exist with the same options and the same event `extraData`.
 
 ## GestureRootView
 
@@ -54,16 +57,14 @@ In case you don't (drawer root view, modals, ...) then you can wrap your views i
 
 ## Overriding Nativescript gestures
 
-This plugin can also override N gestures completely. This would give much more control over gestures and especially would allow to correctly handle simultaneous gestures likes `tap` and `longpress`
+This plugin can also override N gestures completely. This would give much more control over gestures and especially would allow to correctly handle simultaneous gestures likes `tap` and `longpress`.
 
 To do that 
 
 ## Credits
 
 This is a port of [react-native-gesturehandler](https://kmagiera.github.io/react-native-gesture-handler/).
-The source is based on the source code by [Krzysztof Magiera](https://github.com/kmagiera). Dont hesitate to go and thank him for his work!
-
-
+The source is based on the source code by [Krzysztof Magiera](https://github.com/kmagiera). Don't hesitate to go and thank him for his work!
 
 ### Examples:
 


### PR DESCRIPTION
Fixes README's code example in two places: 
1. Missing import of `Manager`.
2. `= =` typo -> `=`

And some minor clean up some spacing, etc.