### PR TITLE
fix(ios): add missing findRootView/findRegistry to Manager

### DIFF
--- a/src/gesturehandler/gesturehandler.ios.ts
+++ b/src/gesturehandler/gesturehandler.ios.ts
@@ -372,6 +372,22 @@ export class Manager extends ManagerBase {
             dispose: onDispose
         });
     }
+    findRootView(view: View): GestureRootView | View {
+        if (view instanceof GestureRootView) {
+            return view;
+        }
+        let parent = view.parent;
+        while (parent) {
+            if (parent instanceof GestureRootView) {
+                return parent;
+            }
+            parent = parent.parent;
+        }
+        return view.page;
+    }
+    findRegistry(view: View) {
+        return this.findRootView(view)?.['registry'];
+    }
     detachGestureHandler(handlerTag: number, view: View) {
         if (view.nativeView) {
             this.manager.dropGestureHandler(handlerTag);


### PR DESCRIPTION
`Manager.findRootView()` is part of the public API and is called from `cancelAllGestures()`, which is mixed into all Views. It was implemented for Android only, causing a runtime crash on iOS for any component relying on gesture cancellation.

Adds `findRootView()` that walks the view hierarchy to the nearest `GestureRootView`, falling back to the page. Adds `findRegistry()` for API parity with Android.
